### PR TITLE
Feature Idea: set_blocks_from_df

### DIFF
--- a/R/data-helpers.R
+++ b/R/data-helpers.R
@@ -306,7 +306,19 @@ set_block <- function(items, traits, names = items, signs = 1) {
   out <- list(blocks = list(nlist(items, traits, names, signs)))
   structure(out, class = "TIRTblocks")
 }
+
 #' @rdname set_block
+#' @export
+empty_block <- function() {
+  structure(list(blocks = list()), class = "TIRTblocks")
+}
+
+#' @export
+"+.TIRTblocks" <- function(e1, e2) {
+  stopifnot(is.TIRTblocks(e2))
+  e1$blocks <- c(e1$blocks, e2$blocks)
+  e1
+}
 
 #' Prepare blocks of items from a dataframe
 #'
@@ -339,11 +351,12 @@ set_block <- function(items, traits, names = items, signs = 1) {
 #'    traits = rep(c("t1", "t2", "t3"), times = 4),
 #'    signs = c(1, 1, 1, -1, 1, 1, 1, 1, -1, 1, -1, 1))
 #'
-#' blocks <- set_blocks(blocks = "block",
-#'                      items = "items",
-#'                      traits = "traits",
-#'                      signs = "signs",
-#'                      data = block_info)
+#' blocks <- set_blocks_from_df(
+#'    blocks = "block",
+#'    items = "items",
+#'    traits = "traits",
+#'    signs = "signs",
+#'    data = block_info)
 #' )
 #'
 #' @export
@@ -366,7 +379,7 @@ set_blocks_from_df <- function(blocks, items, traits, names = items, signs, data
     stop("Only one unique block ID provided.")
   }
 
-  # Fill list with each the set_block call for each block
+  # Fill list with the set_block call for each block
   block_list <- list()
   for(i in 1:length(block_ids)){
     block_list[[i]] <- set_block(items = data[data[ , blocks] == block_ids[i], items],
@@ -381,19 +394,6 @@ set_blocks_from_df <- function(blocks, items, traits, names = items, signs, data
     out$blocks <- c(out$blocks, block_list[[j]]$blocks)
   }
   structure(out, class = "TIRTblocks")
-}
-#' @rdname set_blocks_from_df
-
-#' @export
-empty_block <- function() {
-  structure(list(blocks = list()), class = "TIRTblocks")
-}
-
-#' @export
-"+.TIRTblocks" <- function(e1, e2) {
-  stopifnot(is.TIRTblocks(e2))
-  e1$blocks <- c(e1$blocks, e2$blocks)
-  e1
 }
 
 is.TIRTdata <- function(x) {


### PR DESCRIPTION
Hi Paul,

Loving this package. 

Just a thought: the current method of chaining `set_block` functions manually to specify the items, names, and keys in each block is a bit cumbersome in the case of large questionnaires. In my case, I already had this information at hand for >50 blocks in a dataframe and wanted a quick way of transforming this to a "TIRTblocks" object.

I've created a `set_blocks_from_df` function to do this and am opening a pull request for your consideration. It's really just a wrapper for the `set_block` function, so as to not break any existing functionality. The arguments are mostly names of columns in a pre-existing dataframe specifying the block ID, item, trait, name, and sign column name characters. An example, reproduced here below:

```r
block_info <- data.frame(
    block = rep(1:4, each = 3),
    items = c("i1", "i2", "i3", "i4", "i5", "i6", "i7", "i8", "i9", "i10", "i11", "i12"),
    traits = rep(c("t1", "t2", "t3"), times = 4),
    signs = c(1, 1, 1, -1, 1, 1, 1, 1, -1, 1, -1, 1))

 blocks <- set_blocks_from_df(
    blocks = "block",
    items = "items",
    traits = "traits",
    signs = "signs",
    data = block_info)
 )

triplets_long <- make_TIRT_data(
  data = triplets, blocks = blocks, direction = "larger",
  format = "pairwise", family = "bernoulli", range = c(0, 1)
)

# Same as existing make_TIRT_data example
```

I've already set a couple of seemingly sensible stop functions (e.g. for <2 blocks), but have a look and see if these are ok. Feel free to correct or optimise in any way you see fit. For example, it might be more convenient to evaluate the main arguments with a `deparse(substitute(argument)` to avert the quotations, but I've left it be for the moment. 